### PR TITLE
Mistakes in assertEquals were corrected

### DIFF
--- a/src/test/java/com/epam/university/java/core/task043/Task043Test.java
+++ b/src/test/java/com/epam/university/java/core/task043/Task043Test.java
@@ -34,7 +34,7 @@ public class Task043Test {
                 instance.encode(decodedText)
         );
         assertEquals(
-                "Invalid encoding",
+                "Invalid decoding",
                 decodedText,
                 instance.decode(encodedText)
         );
@@ -50,7 +50,7 @@ public class Task043Test {
                 instance.encode(decodedText)
         );
         assertEquals(
-                "Invalid encoding",
+                "Invalid decoding",
                 decodedText,
                 instance.decode(encodedText)
         );
@@ -69,7 +69,7 @@ public class Task043Test {
                 instance.encode(decodedText)
         );
         assertEquals(
-                "Invalid encoding",
+                "Invalid decoding",
                 decodedText,
                 instance.decode(encodedText)
         );


### PR DESCRIPTION
Hi! This is my first pull request. I've corrected mistakes in messages in _assertEquals_ arguments in Task043Test. In case of test fail _assertEquals_ throw the same message for encoding and decoding.