### PR TITLE
fix rounding for test1

### DIFF
--- a/src/test/java/com/epam/university/java/core/task021/Task021Test.java
+++ b/src/test/java/com/epam/university/java/core/task021/Task021Test.java
@@ -39,7 +39,7 @@ public class Task021Test {
                 pointFactory.newInstance(2, 2),
                 pointFactory.newInstance(1, 2)
         );
-        final Point target = pointFactory.newInstance(1.2113248654051871, 1.788675134594813);
+        final Point target = pointFactory.newInstance(1.211324865405187, 1.788675134594813);
         final Point result = instance.calculate(points);
         assertEquals("Incorrect result in test 1",
                 target,


### PR DESCRIPTION
Hi!

In accordance with Tip 2 (Task021) coordinates must be rounded to 15 digits after the point. But x-coordinate of target point in test1 had 16 digits. So, i've corrected x-coordinate of target point according to Tip 2