### PR TITLE
Test fix for Task060

### DIFF
--- a/src/test/java/com/epam/university/java/core/task060/Task060Test.java
+++ b/src/test/java/com/epam/university/java/core/task060/Task060Test.java
@@ -29,12 +29,12 @@ public class Task060Test {
         assertEquals("Node not found", "test4", instance.get(cache, 4));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testSetWithoutCache() {
         instance.set(null, 1, "test");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testGetWithoutCache() {
         instance.get(null, 1);
     }


### PR DESCRIPTION
Hello. I think there should be IllegalArgumentException instead of RuntimeException, because the main problem is in the argument itself, not in the executing in Runtime.